### PR TITLE
Add support for location modifiers

### DIFF
--- a/nginxparser/__init__.py
+++ b/nginxparser/__init__.py
@@ -15,7 +15,8 @@ class NginxParser(object):
     space = White().suppress()
     key = Word(alphanums + "_/")
     value = CharsNotIn("{};,")
-    location = CharsNotIn("{};,     ")
+    location_modifier = (Literal("=") ^ Literal("~") ^ Literal("~*") ^ Literal("^~")) + space
+    location = Optional(location_modifier) + CharsNotIn("{};,     ")
 
     # rules
     assignment = (key + Optional(space + value) + semicolon)

--- a/tests.py
+++ b/tests.py
@@ -39,6 +39,8 @@ class TestNginxParser(unittest.TestCase):
         self.assertEqual(parsed, [[['foo'], []]])
         parsed = NginxParser.block.parseString('location /foo{}').asList()
         self.assertEqual(parsed, [[['location', '/foo'], []]])
+        parsed = NginxParser.block.parseString('location ~ /foo{}').asList()
+        self.assertEqual(parsed, [[['location', '~', '/foo'], []]])
         parsed = NginxParser.block.parseString('foo { bar foo; }').asList()
         self.assertEqual(parsed, [[['foo'], [['bar', 'foo']]]])
 


### PR DESCRIPTION
According to
http://nginx.org/en/docs/http/ngx_http_core_module.html#location the
location uri can be modified with one of these modifiers: [ = | ~ | ~* |
^~ ].

Added support for parsing this modifier