### PR TITLE
fix: the space between modifier and location rule is optional

### DIFF
--- a/nginxparser.py
+++ b/nginxparser.py
@@ -42,7 +42,7 @@ class NginxParser(object):
     )
 
     block << Group(
-        Group(key + Optional(space + modifier) + Optional(space + location))
+        Group(key + Optional(space + modifier) + Optional(space) + Optional(location))
         + left_bracket
         + Group(subblock)
         + right_bracket

--- a/tests.py
+++ b/tests.py
@@ -28,7 +28,7 @@ class TestNginxParser(unittest.TestCase):
             location ~ case_sensitive\.php$ {
                 hoge hoge;
             }
-            location ~* case_insensitive\.php$ {}
+            location ~*case_insensitive\.php$ {}
             location = exact_match\.php$ {}
             location ^~ ignore_regex\.php$ {}
 


### PR DESCRIPTION
Configure like 'location ~*\.(jpg|png|gif|bmp|ico|swf|ts)$ ' is valid.